### PR TITLE
Create SleepLog formatter for responses

### DIFF
--- a/sleep/src/main/kotlin/com/noom/interview/fullstack/sleep/common/CommonExt.kt
+++ b/sleep/src/main/kotlin/com/noom/interview/fullstack/sleep/common/CommonExt.kt
@@ -1,0 +1,9 @@
+package com.noom.interview.fullstack.sleep.common
+
+import java.time.LocalTime
+
+fun LocalTime.toSeconds() = (hour * 3600 + minute * 60 + second).toLong()
+
+fun List<Pair<Long, Long>>.avgPair(): Pair<Long, Long> =
+    fold(Pair(0L, 0L)) { acc, pair -> Pair(acc.first + pair.first, acc.second + pair.second) }
+    .let { Pair(it.first / size, it.second / size) }

--- a/sleep/src/main/kotlin/com/noom/interview/fullstack/sleep/common/Constants.kt
+++ b/sleep/src/main/kotlin/com/noom/interview/fullstack/sleep/common/Constants.kt
@@ -1,0 +1,8 @@
+package com.noom.interview.fullstack.sleep.common
+
+import java.time.format.DateTimeFormatter
+
+object Constants {
+    val DATE_FORMAT = DateTimeFormatter.ofPattern("yyyy-MM-dd")
+    val TIME_FORMAT = DateTimeFormatter.ofPattern("HH:mm:ss")
+}

--- a/sleep/src/main/kotlin/com/noom/interview/fullstack/sleep/domain/model/SleepLog.kt
+++ b/sleep/src/main/kotlin/com/noom/interview/fullstack/sleep/domain/model/SleepLog.kt
@@ -1,0 +1,19 @@
+package com.noom.interview.fullstack.sleep.domain.model
+
+import com.noom.interview.fullstack.sleep.domain.model.type.SleepRating
+import jakarta.persistence.*
+import java.time.LocalDate
+import java.time.LocalTime
+
+@Entity
+@Table(name = "sleep_log")
+data class SleepLog (
+    @Id @GeneratedValue val id: Long? = null,
+    @Column(columnDefinition = "DATE") val date: LocalDate,
+    @Column(columnDefinition = "TIME") val startTime: LocalTime,
+    @Column(columnDefinition = "TIME") val endTime: LocalTime,
+    val totalTime: Long,
+    @Enumerated(EnumType.ORDINAL) val rating: SleepRating
+)
+
+

--- a/sleep/src/main/kotlin/com/noom/interview/fullstack/sleep/domain/model/aggr/SleepAvg.kt
+++ b/sleep/src/main/kotlin/com/noom/interview/fullstack/sleep/domain/model/aggr/SleepAvg.kt
@@ -1,0 +1,12 @@
+package com.noom.interview.fullstack.sleep.domain.model.aggr
+
+import com.noom.interview.fullstack.sleep.domain.model.type.SleepRating
+import java.time.LocalDate
+import java.time.LocalTime
+
+data class SleepAvg (
+    val avgTime: Long,
+    val avgInterval: Pair<LocalTime, LocalTime>,
+    val period: Pair<LocalDate, LocalDate>,
+    val ratings: Map<SleepRating, Int>,
+)

--- a/sleep/src/main/kotlin/com/noom/interview/fullstack/sleep/domain/model/type/SleepRating.kt
+++ b/sleep/src/main/kotlin/com/noom/interview/fullstack/sleep/domain/model/type/SleepRating.kt
@@ -1,0 +1,5 @@
+package com.noom.interview.fullstack.sleep.domain.model.type
+
+enum class SleepRating {
+    BAD, OK, GOOD
+}

--- a/sleep/src/main/kotlin/com/noom/interview/fullstack/sleep/domain/repository/SleepLogRepository.kt
+++ b/sleep/src/main/kotlin/com/noom/interview/fullstack/sleep/domain/repository/SleepLogRepository.kt
@@ -1,0 +1,11 @@
+package com.noom.interview.fullstack.sleep.domain.repository
+
+import com.noom.interview.fullstack.sleep.domain.model.SleepLog
+import org.springframework.data.domain.Pageable
+import org.springframework.data.repository.PagingAndSortingRepository
+import java.time.LocalDate
+
+interface SleepLogRepository: PagingAndSortingRepository<SleepLog, Long> {
+    fun save(log: SleepLog)
+    fun findAllByDateGreaterThanEqual(date: LocalDate, pageable: Pageable): List<SleepLog>
+}

--- a/sleep/src/main/kotlin/com/noom/interview/fullstack/sleep/domain/usecase/CreateSleepLogUseCase.kt
+++ b/sleep/src/main/kotlin/com/noom/interview/fullstack/sleep/domain/usecase/CreateSleepLogUseCase.kt
@@ -1,0 +1,25 @@
+package com.noom.interview.fullstack.sleep.domain.usecase
+
+import com.noom.interview.fullstack.sleep.domain.model.SleepLog
+import com.noom.interview.fullstack.sleep.domain.model.type.SleepRating
+import com.noom.interview.fullstack.sleep.domain.repository.SleepLogRepository
+import com.noom.interview.fullstack.sleep.common.toSeconds
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Component
+import java.time.LocalDate
+import java.time.LocalTime
+
+@Component
+class CreateSleepLogUseCase(@Autowired val sleepLogRepository: SleepLogRepository) {
+    fun execute(date: LocalDate, startTime: LocalTime, endTime: LocalTime, rating: SleepRating) {
+        sleepLogRepository.save(
+            SleepLog(
+                date = date,
+                startTime = startTime,
+                endTime = endTime,
+                totalTime = endTime.toSeconds() - startTime.toSeconds(),
+                rating = rating
+            )
+        )
+    }
+}

--- a/sleep/src/main/kotlin/com/noom/interview/fullstack/sleep/domain/usecase/GetLastSleepLogUseCase.kt
+++ b/sleep/src/main/kotlin/com/noom/interview/fullstack/sleep/domain/usecase/GetLastSleepLogUseCase.kt
@@ -1,0 +1,15 @@
+package com.noom.interview.fullstack.sleep.domain.usecase
+
+import com.noom.interview.fullstack.sleep.domain.model.SleepLog
+import com.noom.interview.fullstack.sleep.domain.repository.SleepLogRepository
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.data.domain.PageRequest
+import org.springframework.data.domain.Sort
+import org.springframework.stereotype.Component
+
+@Component
+class GetLastSleepLogUseCase(@Autowired val sleepLogRepository: SleepLogRepository) {
+    fun execute(): SleepLog? = sleepLogRepository
+            .findAll(PageRequest.of(0, 1, Sort.by(Sort.Direction.DESC, "date")))
+            .firstOrNull()
+}

--- a/sleep/src/main/kotlin/com/noom/interview/fullstack/sleep/domain/usecase/GetSleepLogAvgUseCase.kt
+++ b/sleep/src/main/kotlin/com/noom/interview/fullstack/sleep/domain/usecase/GetSleepLogAvgUseCase.kt
@@ -1,0 +1,39 @@
+package com.noom.interview.fullstack.sleep.domain.usecase
+
+import com.noom.interview.fullstack.sleep.domain.model.aggr.SleepAvg
+import com.noom.interview.fullstack.sleep.domain.model.type.SleepRating
+import com.noom.interview.fullstack.sleep.domain.repository.SleepLogRepository
+import com.noom.interview.fullstack.sleep.common.avgPair
+import com.noom.interview.fullstack.sleep.common.toSeconds
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.data.domain.Pageable
+import org.springframework.data.domain.Sort
+import org.springframework.stereotype.Component
+import java.time.LocalDate
+import java.time.LocalTime
+
+@Component
+class GetSleepLogAvgUseCase(@Autowired val sleepLogRepository: SleepLogRepository) {
+    fun execute(): SleepAvg? {
+        val sleepLogs = sleepLogRepository.findAllByDateGreaterThanEqual(
+            LocalDate.now().minusMonths(1),
+            Pageable.unpaged(Sort.by(Sort.Direction.DESC, "date"))
+        )
+        val ratings = mapOf(
+            SleepRating.BAD to sleepLogs.count { it.rating == SleepRating.BAD },
+            SleepRating.OK to sleepLogs.count { it.rating == SleepRating.OK },
+            SleepRating.GOOD to sleepLogs.count { it.rating == SleepRating.GOOD },
+        )
+        return if (sleepLogs.isNotEmpty())
+            SleepAvg(
+                sleepLogs.sumOf { it.totalTime }.div(sleepLogs.size.toLong()),
+                sleepLogs
+                    .map { Pair(it.startTime.toSeconds(), it.endTime.toSeconds()) }
+                    .avgPair()
+                    .let { Pair(LocalTime.ofSecondOfDay(it.first), LocalTime.ofSecondOfDay(it.second)) },
+                Pair(sleepLogs.minOf { it.date }, sleepLogs.maxOf { it.date }),
+                ratings
+            )
+        else null
+    }
+}

--- a/sleep/src/main/kotlin/com/noom/interview/fullstack/sleep/presentation/formatter/SleepLogFormatter.kt
+++ b/sleep/src/main/kotlin/com/noom/interview/fullstack/sleep/presentation/formatter/SleepLogFormatter.kt
@@ -1,0 +1,38 @@
+package com.noom.interview.fullstack.sleep.presentation.formatter
+
+import com.noom.interview.fullstack.sleep.common.Constants.DATE_FORMAT
+import com.noom.interview.fullstack.sleep.common.Constants.TIME_FORMAT
+import com.noom.interview.fullstack.sleep.domain.model.SleepLog
+import com.noom.interview.fullstack.sleep.domain.model.aggr.SleepAvg
+import com.noom.interview.fullstack.sleep.domain.model.type.SleepRating
+import com.noom.interview.fullstack.sleep.presentation.model.PeriodFormatted
+import com.noom.interview.fullstack.sleep.presentation.model.SleepLogAvgFormatted
+import com.noom.interview.fullstack.sleep.presentation.model.SleepLogFormatted
+import org.springframework.stereotype.Component
+import java.time.LocalTime
+
+@Component
+class SleepLogFormatter {
+    fun formatSleepLog(sleepLog: SleepLog) = sleepLog.run {
+        SleepLogFormatted (
+            date = date.format(DATE_FORMAT),
+            interval = PeriodFormatted(startTime.format(TIME_FORMAT), endTime.format(TIME_FORMAT)),
+            totalTime = LocalTime.ofSecondOfDay(totalTime).format(TIME_FORMAT),
+            rating = rating.name
+        )
+    }
+
+    fun formatSleepAvg(sleepAvg: SleepAvg) = sleepAvg.run {
+        SleepLogAvgFormatted (
+            avgTime = LocalTime.ofSecondOfDay(avgTime).format(TIME_FORMAT),
+            avgInterval = avgInterval
+                .let { PeriodFormatted(it.first.format(TIME_FORMAT), it.second.format(TIME_FORMAT)) },
+            period = PeriodFormatted(period.first.format(DATE_FORMAT), period.second.format(DATE_FORMAT)),
+            ratingsCount = mapOf(
+                SleepRating.BAD.name to (ratings[SleepRating.BAD] ?: 0),
+                SleepRating.OK.name to (ratings[SleepRating.OK] ?: 0),
+                SleepRating.GOOD.name to (ratings[SleepRating.GOOD] ?: 0)
+            )
+        )
+    }
+}

--- a/sleep/src/main/kotlin/com/noom/interview/fullstack/sleep/presentation/model/PeriodFormatted.kt
+++ b/sleep/src/main/kotlin/com/noom/interview/fullstack/sleep/presentation/model/PeriodFormatted.kt
@@ -1,0 +1,10 @@
+package com.noom.interview.fullstack.sleep.presentation.model
+
+import com.google.gson.annotations.SerializedName
+
+data class PeriodFormatted (
+    @SerializedName("start")
+    val start: String,
+    @SerializedName("end")
+    val end: String
+)

--- a/sleep/src/main/kotlin/com/noom/interview/fullstack/sleep/presentation/model/SleepLogAvgFormatted.kt
+++ b/sleep/src/main/kotlin/com/noom/interview/fullstack/sleep/presentation/model/SleepLogAvgFormatted.kt
@@ -1,0 +1,14 @@
+package com.noom.interview.fullstack.sleep.presentation.model
+
+import com.google.gson.annotations.SerializedName
+
+data class SleepLogAvgFormatted (
+    @SerializedName("avgTime")
+    val avgTime: String,
+    @SerializedName("avgInterval")
+    val avgInterval: PeriodFormatted,
+    @SerializedName("period")
+    val period: PeriodFormatted,
+    @SerializedName("ratingsCount")
+    val ratingsCount: Map<String, Int>,
+)

--- a/sleep/src/main/kotlin/com/noom/interview/fullstack/sleep/presentation/model/SleepLogFormatted.kt
+++ b/sleep/src/main/kotlin/com/noom/interview/fullstack/sleep/presentation/model/SleepLogFormatted.kt
@@ -1,0 +1,14 @@
+package com.noom.interview.fullstack.sleep.presentation.model
+
+import com.google.gson.annotations.SerializedName
+
+data class SleepLogFormatted (
+    @SerializedName("date")
+    val date: String,
+    @SerializedName("interval")
+    val interval: PeriodFormatted,
+    @SerializedName("duration")
+    val totalTime: String,
+    @SerializedName("rating")
+    val rating: String
+)


### PR DESCRIPTION
## What has been done
- Created formatted models to separate domain business from response handling
- Created `SleepLogFormatter` class, that will be responsible for converting business domain to api response models